### PR TITLE
BREAKING CHANGE: Update for Rollup 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "cpy": "^7.0.1",
     "lodash.isobject": "^3.0.2",
     "mkdirp": "^0.5.1"
+  },
+  "peerDependencies": {
+    "rollup": ">= 1.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,11 +2,11 @@ import buble from 'rollup-plugin-buble'
 import json from 'rollup-plugin-json'
 import { main, module, dependencies } from './package.json'
 
-const external = [...Object.keys(dependencies)]
+const external = ['util', ...Object.keys(dependencies)]
 
 export default {
   input: 'src/index.js',
   output: [{ file: main, format: 'cjs' }, { file: module, format: 'es' }],
-  plugins: [json(), buble()],
+  plugins: [json(), buble({ transforms: { asyncAwait: false, forOf: false } })],
   external: external,
 }


### PR DESCRIPTION
- Use the `writeBundle` hook
- Perform the action asynchronously

Closes shrynx/rollup-plugin-cpy#4.